### PR TITLE
Fix some problems with parsing as github-flavored markdown

### DIFF
--- a/docs/i.10.3.2-binary-operators.md
+++ b/docs/i.10.3.2-binary-operators.md
@@ -15,7 +15,7 @@ Binary operators take two operands, perform some operation on them, and return a
  `op_BitwiseAnd` | `&` (binary)
  `op_BitwiseOr` | `\|`
  `op_LogicalAnd` | `&&`
- `op_LogicalOr` | `||`
+ `op_LogicalOr` | `\|\|`
  `op_Assign` | Not defined (`=` is not the same)
  `op_LeftShift` | `<<`
  `op_RightShift` | `>>`

--- a/docs/i.10.3.2-binary-operators.md
+++ b/docs/i.10.3.2-binary-operators.md
@@ -13,7 +13,7 @@ Binary operators take two operands, perform some operation on them, and return a
  `op_Modulus` | `%`
  `op_ExclusiveOr` | `^`
  `op_BitwiseAnd` | `&` (binary)
- `op_BitwiseOr` | `|`
+ `op_BitwiseOr` | `\|`
  `op_LogicalAnd` | `&&`
  `op_LogicalOr` | `||`
  `op_Assign` | Not defined (`=` is not the same)
@@ -38,6 +38,6 @@ Binary operators take two operands, perform some operation on them, and return a
  `op_ModulusAssignment` | `%=`
  `op_AdditionAssignment` | `+=`
  `op_BitwiseAndAssignment` | `&=`
- `op_BitwiseOrAssignment` | `|=`
+ `op_BitwiseOrAssignment` | `\|=`
  `op_Comma` | `,`
  `op_DivisionAssignment` | `/=`

--- a/docs/ii.15.4.1-method-body.md
+++ b/docs/ii.15.4.1-method-body.md
@@ -12,7 +12,7 @@ The method body shall contain the instructions of a program. However, it can als
  | \| `.maxstack` _Int32_ | The `int32` specifies the maximum number of elements on the evaluation stack during the execution of the method. | §[II.15.4.1](ii.15.4.1-method-body.md)
  | \| `.override` _TypeSpec_ `'::'` _MethodName_ | Use current method as the implementation for the method specified. | §[II.10.3.2](ii.10.3.2-the-override-directive.md)
  | \| `.override method` _CallConv_ _Type_ _TypeSpec_ `'::'` _MethodName_ _GenArity_ `'('` _Parameters_ `')'` | Use current method as the implementation for the method specified. | §[II.10.3.2](ii.10.3.2-the-override-directive.md)
- | \| `.param` ``['` _Int32_ `']'` [ `'='` _FieldInit_ ] | Store a constant _FieldInit_ value for parameter _Int32_ | §[II.15.4.1.4](ii.15.4.1.4-the-param-directive.md)
+ | \| `.param` `'['` _Int32_ `']'` [ `'='` _FieldInit_ ] | Store a constant _FieldInit_ value for parameter _Int32_ | §[II.15.4.1.4](ii.15.4.1.4-the-param-directive.md)
  | \| `.param type` `'['` _Int32_ `']'` | Specifies a type parameter for a generic method | §[II.15.4.1.5](ii.15.4.1.5-the-param-type_directive.md)
  | \| _ExternSourceDecl_ | `.line` or `#line` | §[II.5.7](ii.5.7-source-line-information.md)
  | \| _Instr_ | An instruction | [Partition VI](#todo-missing-hyperlink)

--- a/docs/iii.1.2.1-opcode-encodings.md
+++ b/docs/iii.1.2.1-opcode-encodings.md
@@ -9,7 +9,7 @@ The currently defined encodings are specified in [Table 1: Opcode Encodings](#to
  Opcode | Instruction
  ---- | ----
  0x00 | `nop`
- 0x01 | `break `
+ 0x01 | `break`
  0x02 | `ldarg.0`
  0x03 | `ldarg.1`
  0x04 | `ldarg.2`
@@ -74,7 +74,7 @@ The currently defined encodings are specified in [Table 1: Opcode Encodings](#to
  0x40 | `bne.un`
  0x41 | `bge.un`
  0x42 | `bgt.un`
- 0x43 | `ble.un `
+ 0x43 | `ble.un`
  0x44 | `blt.un`
  0x45 | `switch`
  0x46 | `ldind.i1`
@@ -83,7 +83,7 @@ The currently defined encodings are specified in [Table 1: Opcode Encodings](#to
  0x49 | `ldind.u2`
  0x4A | `ldind.i4`
  0x4B | `ldind.u4`
- 0x4C | `ldind.i8 `
+ 0x4C | `ldind.i8`
  0x4D | `ldind.i`
  0x4E | `ldind.r4`
  0x4F | `ldind.r8`
@@ -120,7 +120,7 @@ The currently defined encodings are specified in [Table 1: Opcode Encodings](#to
  0x6E | `conv.u8`
  0x6F | `callvirt`
  0x70 | `cpobj`
- 0x71 | `ldobj `
+ 0x71 | `ldobj`
  0x72 | `ldstr`
  0x73 | `newobj`
  0x74 | `castclass`

--- a/docs/iii.1.5-operand-type-table.md
+++ b/docs/iii.1.5-operand-type-table.md
@@ -50,7 +50,7 @@ Many CIL operations take numeric operands on the stack. These operations fall in
 
 #### Table III.5: Integer Operations
 
- &nbsp; | `int32` | `int64` | `native int` | `F` `&` `O`
+ &nbsp; | `int32` | `int64` | `native int` | `F` | `&` | `O`
  ---- | ---- | ---- | ---- | ---- | ---- | ----
  **`int32`** | `int32` | &cross; | `native int` | &cross; | &cross; | &cross;
  **`int64`** | &cross; | `int64` | &cross; | &cross; | &cross; | &cross;


### PR DESCRIPTION
(It might help to clarify in CONTRIBUTING the files are in https://github.github.com/gfm/ or some other specific markdown dialect.)

Github markdown renders a table cell with `|` as just the \` (see the diff of the github preview.)

Escape the `|` with a backslash
https://stackoverflow.com/a/23734625/771768

This seems more readable that using the HTML entity with Unicode value.

Fix a couple other typos too. Some markdown parsers might be more lenient than github.com